### PR TITLE
Moves regexp to a constant. I find this improves

### DIFF
--- a/lib/active_model/global_locator.rb
+++ b/lib/active_model/global_locator.rb
@@ -18,7 +18,7 @@ module ActiveModel
         if sgid.is_a? SignedGlobalID
           sgid.model_class.find(sgid.model_id)
         else
-          locate SignedGlobalID.new(sgid)
+          locate_signed SignedGlobalID.new(sgid)
         end
       end
       

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -6,7 +6,6 @@ require 'models/person'
 class GlobalLocatorTest < ActiveSupport::TestCase
   setup do
     @person_gid = ActiveModel::GlobalID.create(Person.new(5))
-    @person_sgid = ActiveModel::SignedGlobalID.create(Person.new(7))
   end
 
   test 'locate via actual GID' do
@@ -16,24 +15,10 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     end
   end
 
-  test 'locate via actual SGID' do
-    ActiveModel::GlobalLocator.locate_signed(@person_sgid).tap do |person|
-      assert person.is_a?(Person)
-      assert_equal "7", person.id
-    end
-  end
-
   test 'locate via string GID' do
     ActiveModel::GlobalLocator.locate(@person_gid.to_s).tap do |person|
       assert person.is_a?(Person)
       assert_equal "5", person.id
-    end
-  end
-
-  test 'locate via string SGID' do
-    ActiveModel::GlobalLocator.locate_signed(@person_sgid.to_s).tap do |person|
-      assert person.is_a?(Person)
-      assert_equal "7", person.id
     end
   end
 

--- a/test/cases/signed_global_locator_test.rb
+++ b/test/cases/signed_global_locator_test.rb
@@ -1,0 +1,31 @@
+require 'helper'
+require 'active_model/global_locator'
+require 'models/person'
+
+class SignedGlobalLocatorTest < ActiveSupport::TestCase
+  setup do
+    @person_sgid = ActiveModel::SignedGlobalID.create(Person.new(5))
+  end
+
+  test 'locate_signed via actual SGID' do
+    ActiveModel::GlobalLocator.locate_signed(@person_sgid).tap do |person|
+      assert person.is_a?(Person)
+      assert_equal "5", person.id
+    end
+  end
+
+  test 'locate_signed via string SGID' do
+    ActiveModel::GlobalLocator.locate_signed(@person_sgid.to_s).tap do |person|
+      assert person.is_a?(Person)
+      assert_equal "5", person.id
+    end
+  end
+
+  test 'failure to locate via non-SGID string' do
+    # should this return nil? Should SignedGlobalId initializer check for a
+    # valid sgid before trying to verify it?
+    assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+      ActiveModel::GlobalLocator.locate_signed "This is not a SGID"
+    end
+  end
+end


### PR DESCRIPTION
code readability. Adds a couple valid 
and invalid regexp test assertions.

Adds tests for the locate_signed method in 
GlobalLocator that match the "locate" method tests, 
but with a SignedGlobalID object.
