### PR TITLE
Support for non integer ID

### DIFF
--- a/lib/active_model/global_id.rb
+++ b/lib/active_model/global_id.rb
@@ -16,7 +16,7 @@ module ActiveModel
     end
 
     def model_id
-      @model_id ||= @gid.split("-").third
+      @model_id ||= @gid.split('-')[2..-1].join('-')
     end
 
     def ==(other_global_id)

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -7,7 +7,8 @@ class GlobalIDTest < ActiveSupport::TestCase
   setup do
     @uuid = '7ef9b614-353c-43a1-a203-ab2307851990'
     @person_gid = ActiveModel::GlobalID.create(Person.new(5))
-    @person2_gid = ActiveModel::GlobalID.create(Person.new(@uuid))
+    @person_uuid_gid = ActiveModel::GlobalID.create(Person.new(@uuid))
+    @person_namespaced_gid = ActiveModel::GlobalID.create(Person::Child.new(4))
   end
 
   test 'string representation' do
@@ -15,15 +16,23 @@ class GlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'string representation (uuid)' do
-    assert_equal "GlobalID-Person-#{@uuid}", @person2_gid.to_s
+    assert_equal "GlobalID-Person-#{@uuid}", @person_uuid_gid.to_s
+  end
+
+  test 'string representation (namespaced)' do
+    assert_equal 'GlobalID-Person::Child-4', @person_namespaced_gid.to_s
   end
 
   test 'model id' do
-    assert_equal @uuid, @person2_gid.model_id
+    assert_equal '5', @person_gid.model_id
   end
 
   test 'model id (uuid)' do
-    assert_equal @uuid, @person2_gid.model_id
+    assert_equal @uuid, @person_uuid_gid.model_id
+  end
+
+  test 'model id (namespaced)' do
+    assert_equal '4', @person_namespaced_gid.model_id
   end
 
   test 'model class' do
@@ -31,7 +40,11 @@ class GlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'model class (uuid)' do
-    assert_equal Person, @person2_gid.model_class
+    assert_equal Person, @person_uuid_gid.model_class
+  end
+
+  test 'model class (namespaced)' do
+    assert_equal Person::Child, @person_namespaced_gid.model_class
   end
 
   test 'global ids are values' do
@@ -40,5 +53,9 @@ class GlobalIDTest < ActiveSupport::TestCase
 
   test 'global ids are values (uuid)' do
     assert_equal ActiveModel::GlobalID.create(Person.new(@uuid)), ActiveModel::GlobalID.create(Person.new(@uuid))
+  end
+
+  test 'global ids are values (name_spaced)' do
+    assert_equal ActiveModel::GlobalID.create(Person::Child.new(4)), ActiveModel::GlobalID.create(Person::Child.new(4))
   end
 end

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -5,22 +5,40 @@ require 'models/person'
 
 class GlobalIDTest < ActiveSupport::TestCase
   setup do
+    @uuid = '7ef9b614-353c-43a1-a203-ab2307851990'
     @person_gid = ActiveModel::GlobalID.create(Person.new(5))
+    @person2_gid = ActiveModel::GlobalID.create(Person.new(@uuid))
   end
-  
+
   test 'string representation' do
     assert_equal 'GlobalID-Person-5', @person_gid.to_s
   end
-  
+
+  test 'string representation (uuid)' do
+    assert_equal "GlobalID-Person-#{@uuid}", @person2_gid.to_s
+  end
+
   test 'model id' do
-    assert_equal "5", @person_gid.model_id
+    assert_equal @uuid, @person2_gid.model_id
+  end
+
+  test 'model id (uuid)' do
+    assert_equal @uuid, @person2_gid.model_id
   end
 
   test 'model class' do
     assert_equal Person, @person_gid.model_class
   end
-  
+
+  test 'model class (uuid)' do
+    assert_equal Person, @person2_gid.model_class
+  end
+
   test 'global ids are values' do
     assert_equal ActiveModel::GlobalID.create(Person.new(5)), ActiveModel::GlobalID.create(Person.new(5))
+  end
+
+  test 'global ids are values (uuid)' do
+    assert_equal ActiveModel::GlobalID.create(Person.new(@uuid)), ActiveModel::GlobalID.create(Person.new(@uuid))
   end
 end

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -6,14 +6,27 @@ require 'models/person'
 Person.send :include, ActiveModel::GlobalIdentification
 
 class GlobalIDTest < ActiveSupport::TestCase
-  setup do
-    @person = Person.new(5)
-  end
-  
   test 'global id' do
+    @person = Person.new(5)
     @person.global_id.tap do |global_id|
       assert_equal Person, global_id.model_class
       assert_equal '5', global_id.model_id
+    end
+  end
+
+  test 'global id (uuid)' do
+    @person = Person.new('7ef9b614-353c-43a1-a203-ab2307851990')
+    @person.global_id.tap do |global_id|
+      assert_equal Person, global_id.model_class
+      assert_equal '7ef9b614-353c-43a1-a203-ab2307851990', global_id.model_id
+    end
+  end
+
+  test 'global id (string)' do
+    @person = Person.new('foobar')
+    @person.global_id.tap do |global_id|
+      assert_equal Person, global_id.model_class
+      assert_equal 'foobar', global_id.model_id
     end
   end
 end

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -9,3 +9,5 @@ class Person
     @id = id
   end
 end
+
+class Person::Child < Person; end


### PR DESCRIPTION
before 

```
user = User.first.global_id
#<ActiveModel::GlobalID:0x007fc03365fe50 @gid="GlobalID-User-7ef9b614-353c-43a1-a203-ab2307851990">
user.model_id     #=> "7ef9b614"
```

after 

```
user =User.first.global_id
#<ActiveModel::GlobalID:0x007f1006668948 @gid="GlobalID-User-7ef9b614-353c-43a1-a203-ab2307851990">
user.model_id     #=> "7ef9b614-353c-43a1-a203-ab2307851990"
```
