### PR TITLE
require rails/railtie first

### DIFF
--- a/lib/active_model/railtie.rb
+++ b/lib/active_model/railtie.rb
@@ -1,3 +1,4 @@
+require 'rails/railtie'
 require 'active_model/global_identification'
 
 module ActiveModel


### PR DESCRIPTION
Was getting the following error when trying to load the gem:

```
.../lib/active_model/global_identification.rb:6:in `<module:GlobalIdentification>': uninitialized constant ActiveSupport::Concern (NameError)
  from .../lib/active_model/global_identification.rb:5:in `<module:ActiveModel>'
  from .../lib/active_model/global_identification.rb:4:in `<top (required)>'
  from .../lib/active_model/railtie.rb:3:in `require'
  from .../lib/active_model/railtie.rb:3:in `<top (required)>'
  from .../config/application.rb:4:in `require'
  from .../config/application.rb:4:in `<top (required)>'
```
