### PR TITLE
Changed string format to json; to allow for storage of extra parameters;...

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ be able to use the following methods:
 
 ```ruby
 person_gid = Person.find(5).global_id         # => <#ActiveModel::GlobalID ...
-person_gid.to_s 					          # => "Person-5"
+person_gid.to_json  			      # => {"type":"GlobalID","version":1,"class_name":"Person","id":"5"}
 ActiveModel::GlobalLocator.locate(person_gid) # => <#Person id:5 ...
 ```
 

--- a/lib/active_model/global_id.rb
+++ b/lib/active_model/global_id.rb
@@ -1,10 +1,18 @@
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/array/access'
+require 'json'
 
 module ActiveModel
   class GlobalID
     def self.create(model)
-      new "GlobalID-#{model.class.name}-#{model.id}"
+      id = {
+        type: 'GlobalID',
+        version: 1,
+        class_name: model.class.name,
+        id: model.id.to_s,
+      }.to_json
+
+      new id
     end
 
     def initialize(gid)
@@ -12,11 +20,11 @@ module ActiveModel
     end
 
     def model_class
-      @model_klass ||= @gid.split("-").second.constantize
+      @model_klass ||= JSON.parse(@gid, symbolize_names: true)[:class_name].constantize
     end
 
     def model_id
-      @model_id ||= @gid.split('-')[2..-1].join('-')
+      @model_id ||= JSON.parse(@gid, symbolize_names: true)[:id]
     end
 
     def ==(other_global_id)
@@ -28,3 +36,4 @@ module ActiveModel
     end
   end
 end
+

--- a/lib/active_model/global_locator.rb
+++ b/lib/active_model/global_locator.rb
@@ -1,5 +1,6 @@
 require 'active_model/global_id'
 require 'active_model/signed_global_id'
+require 'json'
 
 module ActiveModel
   class GlobalLocator
@@ -24,7 +25,12 @@ module ActiveModel
       
       private
         def properly_formatted_gid?(gid)
-          gid =~ /GlobalID-([^-]+)-(.+)/
+          begin
+            JSON.parse(gid)
+            return true
+          rescue => e
+            return false
+          end
         end
     end
   end

--- a/lib/active_model/signed_global_id.rb
+++ b/lib/active_model/signed_global_id.rb
@@ -1,13 +1,20 @@
 require 'active_model/global_id'
 require 'active_support/core_ext/module/attribute_accessors'
-
+require 'json'
 
 module ActiveModel
   class SignedGlobalID < GlobalID
     cattr_accessor :verifier
 
     def self.create(model)
-      new verifier.generate("GlobalID-#{model.class.name}-#{model.id}")
+      id = {
+        type: 'GlobalID',
+        version: 1,
+        class_name: model.class.name,
+        id: model.id.to_s,
+      }.to_json
+
+      new verifier.generate(id)
     end
 
     def initialize(sgid)

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -12,15 +12,27 @@ class GlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'string representation' do
-    assert_equal 'GlobalID-Person-5', @person_gid.to_s
+    parsed = JSON.parse(@person_gid.to_s, symbolize_names: true)
+    assert_equal 'GlobalID', parsed[:type]
+    assert_equal 1, parsed[:version]
+    assert_equal 'Person', parsed[:class_name]
+    assert_equal '5', parsed[:id]
   end
 
   test 'string representation (uuid)' do
-    assert_equal "GlobalID-Person-#{@uuid}", @person_uuid_gid.to_s
+    parsed = JSON.parse(@person_uuid_gid.to_s, symbolize_names: true)
+    assert_equal 'GlobalID', parsed[:type]
+    assert_equal 1, parsed[:version]
+    assert_equal 'Person', parsed[:class_name]
+    assert_equal @uuid, parsed[:id]
   end
 
   test 'string representation (namespaced)' do
-    assert_equal 'GlobalID-Person::Child-4', @person_namespaced_gid.to_s
+    parsed = JSON.parse(@person_namespaced_gid.to_s, symbolize_names: true)
+    assert_equal 'GlobalID', parsed[:type]
+    assert_equal 1, parsed[:version]
+    assert_equal 'Person::Child', parsed[:class_name]
+    assert_equal '4', parsed[:id]
   end
 
   test 'model id' do
@@ -59,3 +71,4 @@ class GlobalIDTest < ActiveSupport::TestCase
     assert_equal ActiveModel::GlobalID.create(Person::Child.new(4)), ActiveModel::GlobalID.create(Person::Child.new(4))
   end
 end
+

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -8,8 +8,8 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     @person_gid = ActiveModel::GlobalID.create(Person.new(5))
   end
 
-  test 'locate via actual GID' do
-    ActiveModel::GlobalLocator.locate(@person_gid).tap do |person|
+   test 'locate via actual GID' do
+     ActiveModel::GlobalLocator.locate(@person_gid).tap do |person|
       assert person.is_a?(Person)
       assert_equal "5", person.id
     end

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -11,7 +11,8 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'string representation' do
-    assert_equal 'BAhJIhZHbG9iYWxJRC1QZXJzb24tNQY6BkVU--391ec38a7b004f46caa1acd75bb0f5078e91b4ea', @person_sgid.to_s
+    # TODO: This was cut-n-pasted from the test failure; I don't know enoough about Signed Messages to know if this is the correct value - daniel
+    assert_equal 'BAhJIkN7InR5cGUiOiJHbG9iYWxJRCIsInZlcnNpb24iOjEsImNsYXNzX25hbWUiOiJQZXJzb24iLCJpZCI6IjUifQY6BkVU--77f3d9086c12b0f6a4c10305cf700347a1f2bac8', @person_sgid.to_s
   end
 
   test 'model id' do
@@ -26,3 +27,4 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
     assert_equal ActiveModel::SignedGlobalID.create(Person.new(5)), ActiveModel::SignedGlobalID.create(Person.new(5))
   end
 end
+


### PR DESCRIPTION
Greetings,

I am using Mongoid and I am working on handling nested embedded documents, thus I actually need several keys to properly transverse the document to find the data I am looking for, much in this manner.

User(id)->Profile(id)->Picture(id).   

I was looking at the code and I thought that a JSON formatted string would allow me to store several keys at the same time for embedded documents and moving into the future, extra information such as the database to connect to, and potentially other information would make the id more future proof.

This code doesn't do all of that work; but I wanted to see how you felt about it before committing more work.  All the tests pass.

Regards,

-daniel
