### PR TITLE
Make global locator available through railtie

### DIFF
--- a/lib/active_model/railtie.rb
+++ b/lib/active_model/railtie.rb
@@ -1,5 +1,6 @@
 require 'rails/railtie'
 require 'active_model/global_identification'
+require 'active_model/global_locator'
 
 module ActiveModel
   # = Active Model GlobalID Railtie


### PR DESCRIPTION
User should be able to call `ActiveModel::GlobalLocator.locate('GlobalID-User-123')` without requiring the locator.
