### PR TITLE
implement as_json for Job serialization using JSON

### DIFF
--- a/lib/active_model/global_id.rb
+++ b/lib/active_model/global_id.rb
@@ -26,5 +26,9 @@ module ActiveModel
     def to_s
       @gid
     end
+
+    def as_json(*args)
+      to_s
+    end
   end
 end


### PR DESCRIPTION
Implement `#as_json` to be serialized as a string, in JSON-based job serializer such as Resque. This addresses https://github.com/rails/activejob/issues/95
