### PR TITLE
Represent Global IDs URIs: gid://basecamp/Todo/1234

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-globalid (0.1.2)
+    activemodel-globalid (0.2.0.uri)
       activemodel (>= 4.1.0)
       activesupport (>= 4.1.0)
 

--- a/activemodel-globalid.gemspec
+++ b/activemodel-globalid.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'activemodel-globalid'
-  s.version     = '0.1.2'
+  s.version     = '0.2.0.uri'
   s.summary     = 'Serialize models that can be found by id again (will be part of Active Model).'
   s.description = 'Serializing models to a single string makes it easy to pass references around.'
 

--- a/lib/active_model/global_id/railtie.rb
+++ b/lib/active_model/global_id/railtie.rb
@@ -8,6 +8,8 @@ module ActiveModel
   # #global_id and #signed_global_id.
   class Railtie < Rails::Railtie # :nodoc:
     initializer "active_model.globalid" do
+      ActiveModel::GlobalID.app = Rails.application.railtie_name.remove('_application')
+
       config.after_initialize do |app|
         ActiveModel::SignedGlobalID.verifier = app.message_verifier(:signed_global_ids)
       end

--- a/lib/active_model/global_locator.rb
+++ b/lib/active_model/global_locator.rb
@@ -3,26 +3,13 @@ module ActiveModel
     class << self
       # Takes either a GlobalID or a string that can be turned into a GlobalID
       def locate(gid)
-        if gid.is_a? GlobalID
-          gid.model_class.find(gid.model_id)
-        elsif properly_formatted_gid?(gid)
-          locate GlobalID.new(gid)
-        end
+        GlobalID.find gid
       end
-    
+
       # Takes either a SignedGlobalID or a string that can be turned into a SignedGlobalID
       def locate_signed(sgid)
-        if sgid.is_a? SignedGlobalID
-          sgid.model_class.find(sgid.model_id)
-        else
-          locate_signed SignedGlobalID.new(sgid)
-        end
+        SignedGlobalID.find sgid
       end
-      
-      private
-        def properly_formatted_gid?(gid)
-          gid =~ /GlobalID-([^-]+)-(.+)/
-        end
     end
   end
 end

--- a/lib/active_model/signed_global_id.rb
+++ b/lib/active_model/signed_global_id.rb
@@ -1,23 +1,20 @@
+require 'active_model/global_id'
+require 'active_support/core_ext/module/attribute_accessors'
+
 module ActiveModel
   class SignedGlobalID < GlobalID
     class << self
       attr_accessor :verifier
     end
 
-    def self.create(model)
-      new verifier.generate("GlobalID-#{model.class.name}-#{model.id}")
-    end
-
-    def initialize(sgid)
-      @gid = self.class.verifier.verify(sgid)
-    end
-  
-    def ==(other_global_id)
-      other_global_id.is_a?(SignedGlobalID) && to_s == other_global_id.to_s
+    def self.parse(sgid)
+      sgid.is_a?(self) ? sgid : super(verifier.verify(sgid))
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      nil
     end
 
     def to_s
-      @sgid ||= self.class.verifier.generate(@gid)
+      @sgid ||= self.class.verifier.generate(super)
     end
   end
 end

--- a/lib/activemodel/globalid.rb
+++ b/lib/activemodel/globalid.rb
@@ -1,2 +1,3 @@
 # For Bundler autorequire based on gem name
 require 'active_model/global_id'
+require 'active_model/global_id/railtie'

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -1,7 +1,4 @@
 require 'helper'
-require 'active_model/global_id'
-
-require 'models/person'
 
 class GlobalIDTest < ActiveSupport::TestCase
   setup do
@@ -12,15 +9,27 @@ class GlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'string representation' do
-    assert_equal 'GlobalID-Person-5', @person_gid.to_s
+    assert_equal 'gid://bcx/Person/5', @person_gid.to_s
   end
 
   test 'string representation (uuid)' do
-    assert_equal "GlobalID-Person-#{@uuid}", @person_uuid_gid.to_s
+    assert_equal "gid://bcx/Person/#{@uuid}", @person_uuid_gid.to_s
   end
 
   test 'string representation (namespaced)' do
-    assert_equal 'GlobalID-Person::Child-4', @person_namespaced_gid.to_s
+    assert_equal 'gid://bcx/Person::Child/4', @person_namespaced_gid.to_s
+  end
+
+  test 'uri representation' do
+    assert_equal URI('gid://bcx/Person/5'), @person_gid.uri
+  end
+
+  test 'uri representation (uuid)' do
+    assert_equal URI("gid://bcx/Person/#{@uuid}"), @person_uuid_gid.uri
+  end
+
+  test 'uri representation (namespaced)' do
+    assert_equal URI('gid://bcx/Person::Child/4'), @person_namespaced_gid.uri
   end
 
   test 'model id' do
@@ -33,6 +42,18 @@ class GlobalIDTest < ActiveSupport::TestCase
 
   test 'model id (namespaced)' do
     assert_equal '4', @person_namespaced_gid.model_id
+  end
+
+  test 'model name' do
+    assert_equal 'Person', @person_gid.model_name
+  end
+
+  test 'model name (uuid)' do
+    assert_equal 'Person', @person_uuid_gid.model_name
+  end
+
+  test 'model name (namespaced)' do
+    assert_equal 'Person::Child', @person_namespaced_gid.model_name
   end
 
   test 'model class' do

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -11,7 +11,7 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'string representation' do
-    assert_equal 'BAhJIhZHbG9iYWxJRC1QZXJzb24tNQY6BkVU--391ec38a7b004f46caa1acd75bb0f5078e91b4ea', @person_sgid.to_s
+    assert_equal 'BAhJIhdnaWQ6Ly9iY3gvUGVyc29uLzUGOgZFVA==--c89e90838414d1fee59545b1bd85cfd400ea3362', @person_sgid.to_s
   end
 
   test 'model id' do
@@ -22,7 +22,11 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
     assert_equal Person, @person_sgid.model_class
   end
 
-  test 'signed global ids equality' do
+  test 'value equality' do
     assert_equal ActiveModel::SignedGlobalID.create(Person.new(5)), ActiveModel::SignedGlobalID.create(Person.new(5))
+  end
+
+  test 'value equality with an unsigned id' do
+    assert_equal ActiveModel::GlobalID.create(Person.new(5)), ActiveModel::SignedGlobalID.create(Person.new(5))
   end
 end

--- a/test/cases/signed_global_locator_test.rb
+++ b/test/cases/signed_global_locator_test.rb
@@ -22,10 +22,6 @@ class SignedGlobalLocatorTest < ActiveSupport::TestCase
   end
 
   test 'failure to locate via non-SGID string' do
-    # should this return nil? Should SignedGlobalId initializer check for a
-    # valid sgid before trying to verify it?
-    assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
-      ActiveModel::GlobalLocator.locate_signed "This is not a SGID"
-    end
+    assert_nil ActiveModel::GlobalLocator.locate_signed("This is not a SGID")
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
-require 'bundler'
-Bundler.setup
-
-$LOAD_PATH << File.dirname(__FILE__ + "/../lib")
-
+require 'bundler/setup'
 require 'active_support'
 require 'active_support/testing/autorun'
+
+require 'active_model/global_id'
+require 'models/person'
+ActiveModel::GlobalID.app = 'bcx'


### PR DESCRIPTION
(Moved from #16)
- Share Global IDs among collaborating apps and with non-Ruby/Rails code
- Well-known format with parsers & generators already implemented
- Pave the way to put verifier signature in the URI params, or e.g. a "?version=456" optimistic lock

Next steps:
- [ ] Beef up the URI parser
- [ ] Integrate signing into the URI as a query param
- [ ] Introduce an opaque, url-safe base64 #to_param
